### PR TITLE
added warning for high-z updates if non-default mass range specified

### DIFF
--- a/hmf/_framework.py
+++ b/hmf/_framework.py
@@ -84,10 +84,18 @@ class Framework(object):
         """
         Update parameters of the framework with kwargs.
         """
+        
+        # See issue #6 in HMFCalc        
+        if 'z' in kwargs:
+            if kwargs['z'] >= 2 and (not self._default_masses):
+                print("Warning: High-z untested for non-default masses. See HMFCalc issue #6 for more info.")
+        
         for k, v in list(kwargs.items()):
             if hasattr(self, k):
                 setattr(self, k, v)
                 del kwargs[k]
+
+        
 
         if kwargs:
             raise ValueError("Invalid arguments: %s" % kwargs)

--- a/hmf/hmf.py
+++ b/hmf/hmf.py
@@ -85,6 +85,13 @@ class MassFunction(transfer.Transfer):
         self.hmf_params = hmf_params or {}
         self.filter_model = filter_model
         self.filter_params = filter_params or {}
+        
+        self._default_masses = True
+        if (Mmin != 10) or (Mmax != 15):
+            self._default_masses = False
+            
+            if self.z >= 2:
+                print("Warning: High-z untested for non-default masses. See HMFCalc issue #6 for more info.")
 
     #===========================================================================
     # PARAMETERS


### PR DESCRIPTION
This is in response to [issue #6 in HMFCalc](https://github.com/steven-murray/HMFcalc/issues/6#issuecomment-393055571). It's not pretty, but it provides some info to users looking at z>=2 and non-default mass ranges. 