### PR TITLE
growth factor speed-up

### DIFF
--- a/hmf/growth_factor.py
+++ b/hmf/growth_factor.py
@@ -121,7 +121,8 @@ class GrowthFactor(Cmpt):
             The normalised growth factor as a function of redshift, or
             redshift as a function of growth factor if ``inverse`` is True.
         """
-        growth = self._d_plus(zmin, True)/self._d_plus(0.0)
+        dp = self._d_plus(0.0, True)
+        growth = dp / dp[-1]
         if not inverse:
             s = _spline(self._zvec[::-1], growth[::-1])
         else:

--- a/hmf/transfer.py
+++ b/hmf/transfer.py
@@ -267,11 +267,18 @@ class Transfer(cosmo.Cosmology):
                              **self.growth_params)
 
     @cached_quantity
+    def _growth_factor_fn(self):
+        """
+            Function that efficiently returns the growth factor.
+        """
+        return self.growth.growth_factor_fn()
+
+    @cached_quantity
     def growth_factor(self):
         r"""
         The growth factor
         """
-        return self.growth.growth_factor(self.z)
+        return self._growth_factor_fn(self.z)
 
     @cached_quantity
     def power(self):

--- a/hmf/transfer.py
+++ b/hmf/transfer.py
@@ -42,7 +42,7 @@ class Transfer(cosmo.Cosmology):
     def __init__(self, sigma_8=0.8159, n=0.9667, z=0.0, lnk_min=np.log(1e-8),
                  lnk_max=np.log(2e4), dlnk=0.05, transfer_model=tm.CAMB if HAVE_PYCAMB else tm.EH,
                  transfer_params=None, takahashi=True, growth_model=gf.GrowthFactor,
-                 growth_params=None, **kwargs):
+                 growth_params=None, use_splined_growth=False, **kwargs):
 
         # Call Cosmology init
         super(Transfer, self).__init__(**kwargs)
@@ -52,6 +52,7 @@ class Transfer(cosmo.Cosmology):
         self.sigma_8 = sigma_8
         self.growth_model = growth_model
         self.growth_params = growth_params or {}
+        self.use_splined_growth = use_splined_growth
         self.lnk_min = lnk_min
         self.lnk_max = lnk_max
         self.dlnk = dlnk
@@ -269,7 +270,7 @@ class Transfer(cosmo.Cosmology):
     @cached_quantity
     def _growth_factor_fn(self):
         """
-            Function that efficiently returns the growth factor.
+        Function that efficiently returns the growth factor.
         """
         return self.growth.growth_factor_fn()
 
@@ -278,7 +279,10 @@ class Transfer(cosmo.Cosmology):
         r"""
         The growth factor
         """
-        return self._growth_factor_fn(self.z)
+        if self.use_splined_growth:
+            return self._growth_factor_fn(self.z)
+        else:
+            return self.growth.growth_factor(self.z)
 
     @cached_quantity
     def power(self):


### PR DESCRIPTION
This PR is to speed up calls to transfer.growth_factor. We noticed that it was a bottleneck in our code since every time the growth factor was recalculated, it would re-run the d_plus integral twice. Since we are updating z a lot, this was causing some significant slow-downs. 

I noticed that you already provide a splined implementation in `growth_factor_fn`, but you weren't using it in the transfer class. This just changes that, so you only need to calculate the d_plus integral once. Is there any reason this is not done by default?

The change in the `growth_factor.growth_factor_fn` is to address the fact that if zmin != 0 the sizes of the `growth` array and the `_zvec` array would be different, since `_d_plus(0.0)` re-calculates `_zvec`. Is there any reason not to have `zmin=0`, since the entire integral is calculated anyway?

Hopefully this is helpful to other people, and definitely let me know if there's anything that I'm missing! Thanks.

