### PR TITLE
Add bump-version workflow

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -1,0 +1,16 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Bump version and push tag
+        uses: mathieudutour/github-tag-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: null
+          dry_run: true


### PR DESCRIPTION
Adds a version bumping workflow.

Should only run once something has been merged to master, and should only actually bump version when a commit has been made with a certain kind of tag in it.