### PR TITLE
chore: update bump-version checkout to include full history

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        # Ensure full history is gotten.
+        with:
+          fetch-depth: 0
       - name: Bump version and push tag
         uses: mathieudutour/github-tag-action@v4.5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/_*/*
 
 \.tox/log/
 .coverage
+pip-wheel-metadata/


### PR DESCRIPTION
This should hopefully fix the bump_version action which was not looking at the full commit history.