### PR TITLE
fix: deprecate astropy_to_colossus in favour of using colossus directly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ dev =
     pytest-cov>=2.5.1
     pre-commit
     mpmath>=1.0.0
-    colossus>=1.2.1
+    colossus>=1.2.16
     halomod==1.4.6.dev58
 cosmo =
     colossus>=1.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     scipy>=0.12.0
     astropy>=1.1
     camb>=1.0.0<2.0
+    deprecation
 
 [options.packages.find]
 where = src

--- a/src/hmf/cosmology/cosmo.py
+++ b/src/hmf/cosmology/cosmo.py
@@ -32,7 +32,7 @@ def astropy_to_colossus(cosmo: FLRW, name: str = "custom", **kwargs):
         from colossus.cosmology import cosmology
 
         return cosmology.fromAstropy(astropy_cosmo=cosmo, cosmo_name=name, **kwargs)
-    except ImportError:
+    except ImportError:  # pragma: nocover
         raise ImportError(
             "Cannot convert to COLOSSUS cosmology without installing COLOSSUS!"
         )

--- a/src/hmf/cosmology/cosmo.py
+++ b/src/hmf/cosmology/cosmo.py
@@ -14,52 +14,28 @@ may be used as inputs.
 from astropy.cosmology import FLRW, Planck15, WMAP5, WMAP7, WMAP9, Planck13  # noqa
 from astropy import cosmology as acsm
 from .._internals import _framework, _cache
+from .. import __version__
 import sys
 import astropy.units as u
-
-try:
-    from colossus.cosmology import cosmology
-
-    HAVE_COLOSSUS = True
-except ImportError:
-    HAVE_COLOSSUS = False
+import deprecation
 
 
+@deprecation.deprecated(
+    deprecated_in="3.1.3",
+    removed_in="4.0",
+    current_version=__version__,
+    details="Use the cosmology.fromAstropy function in COLOSSUS instead",
+)
 def astropy_to_colossus(cosmo: FLRW, name: str = "custom", **kwargs):
     """Convert an astropy cosmology to a COLOSSUS cosmology"""
-    # Find appropriate w(z) arguments.
-    if not HAVE_COLOSSUS:
-        raise ImportError("You need COLOSSUS to use this function!")
+    try:
+        from colossus.cosmology import cosmology
 
-    if isinstance(cosmo, acsm.wpwaCDM):
-        kwargs.update(de_model="user")
-        kwargs.update(
-            wz_function=lambda z: cosmo.wp + cosmo.wa * (cosmo.ap - 1 / (1 + z))
+        return cosmology.fromAstropy()
+    except ImportError:
+        raise ImportError(
+            "Cannot convert to COLOSSUS cosmology without installing COLOSSUS!"
         )
-    elif isinstance(cosmo, acsm.w0waCDM):
-        kwargs.update(de_model="w0wa")
-        kwargs.update(w0=cosmo.w0)
-        kwargs.update(wa=cosmo.wa)
-    elif isinstance(cosmo, acsm.w0wzCDM):
-        kwargs.update(de_model="user")
-        kwargs.update(wz_function=lambda z: cosmo.w0 + cosmo.wz * z)
-    elif isinstance(cosmo, acsm.wCDM):
-        kwargs.update(de_model="w0")
-        kwargs.update(w0=cosmo.w0)
-
-    return cosmology.setCosmology(
-        name,
-        params=dict(
-            flat=cosmo.Ok0 == 0,
-            H0=cosmo.H0.value,
-            Om0=cosmo.Om0,
-            Ode0=cosmo.Ode0,
-            Ob0=cosmo.Ob0,
-            Tcmb0=cosmo.Tcmb0.value,
-            Neff=cosmo.Neff,
-            **kwargs
-        ),
-    )
 
 
 class Cosmology(_framework.Framework):

--- a/src/hmf/cosmology/cosmo.py
+++ b/src/hmf/cosmology/cosmo.py
@@ -31,7 +31,7 @@ def astropy_to_colossus(cosmo: FLRW, name: str = "custom", **kwargs):
     try:
         from colossus.cosmology import cosmology
 
-        return cosmology.fromAstropy()
+        return cosmology.fromAstropy(astropy_cosmo=cosmo, cosmo_name=name, **kwargs)
     except ImportError:
         raise ImportError(
             "Cannot convert to COLOSSUS cosmology without installing COLOSSUS!"

--- a/tests/test_cosmo.py
+++ b/tests/test_cosmo.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
+import deprecation
 
-from hmf.cosmology.cosmo import Cosmology
+from hmf.cosmology.cosmo import Cosmology, astropy_to_colossus
 from astropy.cosmology import WMAP7
 
 
@@ -31,3 +32,11 @@ def test_cosmo_params(cosmo):
     assert cosmo.cosmo.Om0 == 0.2
     assert cosmo.cosmo.H0.value == 0.6
     assert cosmo.cosmo_params == {"Om0": 0.2, "H0": 0.6}
+
+
+@deprecation.fail_if_not_removed
+def test_cosmo_to_colossus():
+    colossus = astropy_to_colossus(cosmo=WMAP7, name="wmap7", sigma8=0.8, ns=1.0)
+
+    assert colossus.sigma8 == 0.8
+    assert colossus.ns == 1.0

--- a/tests/test_mdef.py
+++ b/tests/test_mdef.py
@@ -11,10 +11,14 @@ from astropy.cosmology import Planck15
 import numpy as np
 
 # Set COLOSSUS cosmology
-setCosmology("planck15")
 
 
-def test_mean_to_mean_nfw():
+@pytest.fixture(scope="function")
+def colossus_cosmo():
+    setCosmology("planck15")
+
+
+def test_mean_to_mean_nfw(colossus_cosmo):
     mdef = md.SOMean(overdensity=200)
     mdef2 = md.SOMean(overdensity=300)
     cduffy = mdef._duffy_concentration(1e12)
@@ -28,7 +32,7 @@ def test_mean_to_mean_nfw():
     assert np.isclose(cnew, cnew_, rtol=1e-2)
 
 
-def test_mean_to_crit_nfw():
+def test_mean_to_crit_nfw(colossus_cosmo):
     mdef = md.SOMean(overdensity=200)
     mdef2 = md.SOCritical(overdensity=300)
 
@@ -42,7 +46,7 @@ def test_mean_to_crit_nfw():
     assert np.isclose(cnew, cnew_, rtol=1e-2)
 
 
-def test_mean_to_crit_z1_nfw():
+def test_mean_to_crit_z1_nfw(colossus_cosmo):
     mdef = md.SOMean(overdensity=200)
     mdef2 = md.SOCritical(overdensity=300)
 
@@ -57,7 +61,7 @@ def test_mean_to_crit_z1_nfw():
     assert np.isclose(cnew, cnew_, rtol=1e-2)
 
 
-def test_mean_to_vir_nfw():
+def test_mean_to_vir_nfw(colossus_cosmo):
     mdef = md.SOMean()
     mdef2 = md.SOVirial()
 
@@ -66,19 +70,21 @@ def test_mean_to_vir_nfw():
     mnew, rnew, cnew = mdef.change_definition(1e12, mdef2)
     mnew_, rnew_, cnew_ = changeMassDefinition(1e12, cduffy, 0, "200m", "vir", "nfw")
 
+    print(mnew, mnew_)
+
     assert np.isclose(mnew, mnew_, rtol=1e-2)
     assert np.isclose(rnew * 1e3, rnew_, rtol=1e-2)
     assert np.isclose(cnew, cnew_, rtol=1e-2)
 
 
-def test_colossus_name():
+def test_colossus_name(colossus_cosmo):
     assert md.SOMean().colossus_name == "200m"
     assert md.SOCritical().colossus_name == "200c"
     assert md.SOVirial().colossus_name == "vir"
     assert md.FOF().colossus_name == "fof"
 
 
-def test_from_colossus_name():
+def test_from_colossus_name(colossus_cosmo):
     assert md.from_colossus_name("200c") == md.SOCritical()
     assert md.from_colossus_name("200m") == md.SOMean()
     assert md.from_colossus_name("fof") == md.FOF()
@@ -89,7 +95,7 @@ def test_from_colossus_name():
         md.from_colossus_name("derp")
 
 
-def test_change_dndm():
+def test_change_dndm(colossus_cosmo):
     h = MassFunction(
         mdef_model="SOVirial", hmf_model="Warren", disable_mass_conversion=False
     )


### PR DESCRIPTION
Deprecates astropy_to_colossus