### PR TITLE
Faster camb

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,11 @@ dev
 ---
 **Features**
 - Option to extrapolate high-k for CAMB transfer using EH. This gives a fast and
-  reasonably consistent high-k transfer function. If not extrapolating with EH (this
-  is the default) a higher kmax is set by default, to enable better accuracy.
+  reasonably consistent high-k transfer function. If not extrapolating with EH (which
+  is still the default) you can now set ``transfer_params={'kmax':1e3}`` to get better
+  low-mass/small-scale accuracy. By default, kmax is the same as the default from
+  CAMB, which is about 1.4 h/Mpc. Above this value, the transfer function is by default
+  linearly extrapolated in log-log space.
 - Components now automatically keep track of models, and the base component class
   tracks Component types. This also means that user-defined models can be input via
   strings into a framework (useful for running from CLI).

--- a/src/hmf/density_field/transfer_models.py
+++ b/src/hmf/density_field/transfer_models.py
@@ -164,6 +164,7 @@ if HAVE_CAMB:
             "camb_params": None,
             "dark_energy_params": {},
             "extrapolate_with_eh": False,
+            "kmax": None,
         }
 
         def __init__(self, *args, **kwargs):
@@ -191,10 +192,8 @@ if HAVE_CAMB:
 
                 # If extrapolating with EH, use a lower value of kmax so that the
                 # calculation is faster.
-                if self.params["extrapolate_with_eh"]:
-                    self.params["camb_params"].Transfer.kmax = 2
-                else:
-                    self.params["camb_params"].Transfer.kmax = 1e3
+                if self.params["kmax"]:
+                    self.params["camb_params"].Transfer.kmax = self.params["kmax"]
 
             if self.cosmo.Ob0 is None:
                 raise ValueError(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -75,8 +75,6 @@ def test_data(datadir):
 def test_camb_extrapolation():
     t = Transfer(transfer_params={"extrapolate_with_eh": True})
 
-    assert t.transfer.params["camb_params"].Transfer.kmax == 2
-
     k = np.logspace(1.5, 2, 20)
     eh = t.transfer._eh.lnt(np.log(k))
     camb = t.transfer.lnt(np.log(k))


### PR DESCRIPTION
This makes the default behaviour of CAMB be to calculate up to camb's default of kmax=1.4. However, it adds the option of changing this maximum easily, which may be important for `halomod` and other codes that need high-accuracy small-scale structure. 