### PR TITLE
maint: make camb no longer installed by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Releases
 ========
+dev-version
+-----------
+**Changes**
+
+- ``camb`` is no longer installed by default. If you want to install it along with ``hmf``
+  (as well as other useful utilities) install with ``pip install hmf[all]``.
 
 v3.3.1 [30th Nov 2020]
 ----------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ install_requires =
     numpy>=1.6.2
     scipy>=0.12.0
     astropy>=1.1
-    camb>=1.0.0<2.0
     deprecation
     click
     toml>=0.10.1
@@ -84,6 +83,10 @@ dev =
 cosmo =
     colossus>=1.2.1
 fit =
+    emcee>=3.0
+all =
+    camb>=1.0.0<2.0
+    colossus>=1.2.1
     emcee>=3.0
 
 [options.entry_points]


### PR DESCRIPTION
<!--
Thank you for creating a PR on hmf!

Please read through the following and check the boxes to ensure
your PR meets our coding standards and that it follows the
correct pathways for testing and deployment.
-->

# Description
<!-- Write a brief description of what the new feature does, and how a review could take it for a spin -->
Simply takes camb out of install_requires, and adds it to the `all` extra. Users with `camb` already installed
should see no difference.
