### PR TITLE
Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Releases
 ========
-dev-version
------------
+v3.3.2 [11th Dec 2020]
+----------------------
 **Changes**
 
 - ``camb`` is no longer installed by default. If you want to install it along with ``hmf``


### PR DESCRIPTION
v3.3.2

**Changes**

- ``camb`` is no longer installed by default. If you want to install it along with ``hmf``
  (as well as other useful utilities) install with ``pip install hmf[all]``.