### PR TITLE
fix neutrino mass parameter in camb

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ v3.3.2 [11th Dec 2020]
 - ``camb`` is no longer installed by default. If you want to install it along with ``hmf``
   (as well as other useful utilities) install with ``pip install hmf[all]``.
 
+**Bugfixes**
+
+- Redefined omch2 to account for massive neutrinos `PR #118 <https://github.com/steven-murray/hmf/pull/118>`_
+
 v3.3.1 [30th Nov 2020]
 ----------------------
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -7,6 +7,7 @@ Contributors
 * Jordan Mirocha (UCLA): `@mirochaj <https://github.com/mirochaj>`_
 * `@jlashner <https://github.com/jlashner>`_
 * `@liweitianux <https://github.com/liweitianux>`_
+* Jia Liu (UC Berkeley): `@liuxx479 <https://github.com/liuxx479>`_
 
 Comments, corrections and suggestions
 -------------------------------------

--- a/src/hmf/density_field/transfer_models.py
+++ b/src/hmf/density_field/transfer_models.py
@@ -209,7 +209,10 @@ if HAVE_CAMB:
             self.params["camb_params"].set_cosmology(
                 H0=self.cosmo.H0.value,
                 ombh2=self.cosmo.Ob0 * self.cosmo.h ** 2,
-                omch2=(self.cosmo.Om0 - self.cosmo.Ob0) * self.cosmo.h ** 2,
+                omch2=(self.cosmo.Om0 - self.cosmo.Ob0 - self.cosmo.Onu0)
+                * self.cosmo.h ** 2,
+                mnu=sum(self.cosmo.m_nu.value),
+                neutrino_hierarchy="degenerate",
                 omk=self.cosmo.Ok0,
                 nnu=self.cosmo.Neff,
                 standard_neutrino_neff=self.cosmo.Neff,


### PR DESCRIPTION
Originally, omega_cdm (`omch2`) assumes all matter in cold dark matter and baryons, and ignores massive neutrinos:
`omch2=(self.cosmo.Om0 - self.cosmo.Ob0) * self.cosmo.h ** 2`

I changed the definition to include massive neutrinos:
`omch2=(self.cosmo.Om0 - self.cosmo.Ob0 **- self.cosmo.Onu0**) * self.cosmo.h ** 2`
where I used astropy's cosmo.Onu0 calculation.

In addition, camb requires the neutrino mass and hierarchy.. I did not fix the code for different hierarchies (normal, inverted, degenerate) since it should be a sub-percent effect that's not observable by near future LSS surveys. So I assumed degenerate hierarchy (i.e. the 3 neutrinos are assumed to have equal mass = 1/3 *total mass):

```
mnu=sum(self.cosmo.m_nu.value)
neutrino_hierarchy='degenerate'
```