### PR TITLE
fix: add validate() method to catch more errors quickly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,10 @@ dev-version
 **Bugfixes**
 
 - Added ``validate()`` method that is automatically called after ``__init__()`` and
-  ``update()`` and also on every ``parameter`` update. This can cross-validate different
-  inputs.
+  ``update()`` and also (optionally) on every ``parameter`` update. This can cross-validate different
+  inputs. **NOTE**: if you currently have code that sets parameters directly, eg ``mf.z=2.0``,
+  you should update to using the ``update()`` method, as this allows multiple parameters
+  to be set, and then a call to ``validate()``.
 
 v3.3.3 [21 Dec 2020]
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Releases
 dev-version
 ----------------------
 
+**Bugfixes**
+
+- Added ``validate()`` method that is automatically called after ``__init__()`` and
+  ``update()`` and also on every ``parameter`` update. This can cross-validate different
+  inputs.
+
 v3.3.3 [21 Dec 2020]
 ----------------------
 **Bugfixes**

--- a/src/hmf/_internals/_cache.py
+++ b/src/hmf/_internals/_cache.py
@@ -229,7 +229,7 @@ def parameter(kind):
                 and not isinstance(val, dict)
                 and val is not None
             ):
-                raise ValueError("%s must be a dictionary" % name)
+                raise ValueError(f"{name} must be a dictionary")
 
             # Locations of indexes
             recalc = hidden_loc(self, "recalc")
@@ -279,6 +279,9 @@ def parameter(kind):
                     # so need to re-index
                     for pr in getattr(self, recalc_papr)[name]:
                         delattr(self, pr)
+
+                if not doset and self._validate:
+                    self.validate()
 
         update_wrapper(_set_property, f)
 

--- a/src/hmf/_internals/_cache.py
+++ b/src/hmf/_internals/_cache.py
@@ -281,7 +281,16 @@ def parameter(kind):
                         delattr(self, pr)
 
                 if not doset and self._validate:
-                    self.validate()
+                    if self._validate_every_param_set:
+                        self.validate()
+                    else:
+                        warnings.warn(
+                            f"You are setting {name} directly. This is unstable, as less "
+                            f"validation is performed. You can turn on extra validation "
+                            f"for directly set parameters by setting framework._validate_every_param_set=True."
+                            f"However, this can be brittle, since intermediate states may not be valid.",
+                            category=DeprecationWarning,
+                        )
 
         update_wrapper(_set_property, f)
 

--- a/src/hmf/_internals/_framework.py
+++ b/src/hmf/_internals/_framework.py
@@ -207,6 +207,7 @@ class Framework(metaclass=_Validator):
     """
 
     _validate = True
+    _validate_every_param_set = False
 
     def validate(self):
         pass

--- a/src/hmf/cosmology/cosmo.py
+++ b/src/hmf/cosmology/cosmo.py
@@ -63,7 +63,7 @@ class Cosmology(_framework.Framework):
 
     def __init__(self, cosmo_model=Planck15, cosmo_params=None):
         # Call Framework init
-        super(Cosmology, self).__init__()
+        super().__init__()
 
         # Set all given parameters
         self.cosmo_model = cosmo_model

--- a/src/hmf/density_field/transfer.py
+++ b/src/hmf/density_field/transfer.py
@@ -57,11 +57,11 @@ class Transfer(cosmo.Cosmology):
         growth_model=None,
         growth_params=None,
         use_splined_growth=False,
-        **kwargs
+        **kwargs,
     ):
 
         # Call Cosmology init
-        super(Transfer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Set all given parameters
         self.n = n
@@ -90,6 +90,12 @@ class Transfer(cosmo.Cosmology):
     # ===========================================================================
     # Parameters
     # ===========================================================================
+    def validate(self):
+        super().validate()
+        assert (
+            self.lnk_min < self.lnk_max
+        ), f"lnk_min >= lnk_max: {self.lnk_min}, {self.lnk_max}"
+        assert len(self.k) > 1, f"len(k) < 2: {len(self.k)}"
 
     @parameter("model")
     def growth_model(self, val):

--- a/src/hmf/mass_function/hmf.py
+++ b/src/hmf/mass_function/hmf.py
@@ -88,7 +88,7 @@ class MassFunction(transfer.Transfer):
         **transfer_kwargs,
     ):
         # Call super init MUST BE DONE FIRST.
-        super(MassFunction, self).__init__(**transfer_kwargs)
+        super().__init__(**transfer_kwargs)
 
         # Set all given parameters.
         self.hmf_model = hmf_model
@@ -106,6 +106,11 @@ class MassFunction(transfer.Transfer):
     # ===========================================================================
     # PARAMETERS
     # ===========================================================================
+    def validate(self):
+        super().validate()
+        assert self.Mmin < self.Mmax, f"Mmin > Mmax: {self.Mmin}, {self.Mmax}"
+        assert len(self.m) > 0, "mass vector has length zero!"
+
     @parameter("res")
     def Mmin(self, val):
         r"""

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -6,6 +6,7 @@ from hmf._internals import pluggable, get_base_components, get_base_component
 from hmf._internals._framework import get_model_
 from deprecation import fail_if_not_removed
 from hmf import GrowthFactor
+from hmf import MassFunction
 
 
 def test_incorrect_argument():
@@ -89,3 +90,22 @@ def test_get_model():
 
 def test_growth_plugins():
     assert "GenMFGrowth" in GrowthFactor._plugins
+
+
+def test_validate_inputs():
+    with pytest.raises(AssertionError):
+        MassFunction(Mmin=10, Mmax=9)
+
+    m = MassFunction(Mmin=10, Mmax=11)
+    with pytest.raises(AssertionError):
+        m.update(Mmax=9)
+
+    # Without checking on, we can still manually set it, but it will warn us
+    with pytest.warns(DeprecationWarning):
+        m.Mmax = 9
+        m.Mmin = 8
+
+    # But with checking on, we can't
+    m._validate_every_param_set = True
+    with pytest.raises(AssertionError):
+        m.Mmax = 7


### PR DESCRIPTION
Adds a `validate()` method to frameworks that is called automatically at the end of `__init__()` and `update()` and also after each individual parameter setting. 