### PR TITLE
docs: fix duplicated word in dlnss_dlnr docstring

### DIFF
--- a/src/hmf/density_field/filters.py
+++ b/src/hmf/density_field/filters.py
@@ -185,7 +185,7 @@ class BaseFilter(_framework.Component):
         Returns
         -------
         dlnss_dlnr : array_like
-            The derivative of the the mass variance with radius.
+            The derivative of the mass variance with radius.
 
         Notes
         -----


### PR DESCRIPTION
## Summary
- Fixes a small typo ("the the" → "the") in the `dlnss_dlnr` docstring in `src/hmf/density_field/filters.py`.

## Test plan
- [x] Docs-only change, no functional code affected.