### PR TITLE
docs: cite Yung+24/25 on colossus comparison, fix Yung24 ref

### DIFF
--- a/docs/technical/colossus_comparison.rst
+++ b/docs/technical/colossus_comparison.rst
@@ -16,6 +16,12 @@ correct". Instead, it records the main implementation choices that explain the
 observed residual differences so that users and developers understand where
 agreement is expected and where small systematic offsets are normal.
 
+This investigation was itself prompted by Aaron Yung and Miguel Vargas, who
+independently noticed disagreement between ``hmf`` and Colossus predictions for
+the Tinker08 mass function while preparing [Yung24]_ and [Yung25]_. Their reports
+are what led to the growth-factor fix linked above, and we are grateful to them
+for flagging the discrepancy and giving permission to reference their work here.
+
 Setup of the comparison
 -----------------------
 
@@ -122,3 +128,8 @@ typically of order:
 - ``z = 10``: :math:`\sim 2\%` to :math:`14\%`,
 
 over the range :math:`10^{11}`--:math:`10^{13}\,M_\odot/h`.
+
+References
+----------
+.. [Yung24] Yung, L. Y. Aaron, Rachel S. Somerville, Tri Nguyen, Peter Behroozi, Chirag Modi, and Jonathan P. Gardner. 'Characterizing Ultra-High-Redshift Dark Matter Halo Demographics and Assembly Histories with the GUREFT Simulations'. Monthly Notices of the Royal Astronomical Society 530, no. 4 (2024): 4868-86. https://doi.org/10.1093/mnras/stae1188.
+.. [Yung25] Yung, L. Y. Aaron, Rachel S. Somerville, and Kartheik G. Iyer. 'ΛCDM Is Still Not Broken: Empirical Constraints on the Star Formation Efficiency at z ~ 12-30'. Monthly Notices of the Royal Astronomical Society 543, no. 4 (2025): 3802-13. https://doi.org/10.1093/mnras/staf1699.

--- a/src/hmf/mass_function/fitting_functions.py
+++ b/src/hmf/mass_function/fitting_functions.py
@@ -2001,8 +2001,8 @@ class Yung24(BaseFittingFunction):
 
     _eq = r"A(z)\left[(\sigma/b(z))^{-a(z)} + 1\right]\exp(-c(z)/\sigma^2)"
     _ref = (
-        "Yung, L.Y.A., Somerville, R.S., Finkelstein, S.L., Wilkins, S.M., "
-        "Gardner, J.P., 2024. MNRAS 527, 5929. arXiv:2309.14408"
+        "Yung, L.Y.A., Somerville, R.S., Nguyen, T., Behroozi, P., Modi, C., "
+        "Gardner, J.P., 2024. MNRAS 530, 4868. arXiv:2309.14408"
     )
 
     sim_definition = SimDetails(


### PR DESCRIPTION
# Description

Aaron Yung and Miguel Vargas independently noticed the hmf/Colossus Tinker08 disagreement while preparing their papers, and that report is what led to the growth-factor fix (#270) and the follow-up threshold tightening in v3.6.1. They've given permission to cite their work on the comparison page.

This PR:
- Adds a short note near the top of [`docs/technical/colossus_comparison.rst`](docs/technical/colossus_comparison.rst) crediting Yung and Vargas, with proper citations to:
  - Yung et al. 2024, MNRAS 530, 4868
  - Yung et al. 2025, MNRAS 543, 3802
- Follows the repo's existing citation convention (plain reST `[Label]_` citations + a `References` section, as used in `growth_factors.rst`) — there's no `CITATIONS.bib`/`CITATION.cff` in the repo to extend, so no new bibliography format was introduced.
- Fixes an unrelated but adjacent bug I noticed while verifying the 2024 reference: `Yung24._ref` in `src/hmf/mass_function/fitting_functions.py` cited the wrong author list (Finkelstein/Wilkins instead of Nguyen/Behroozi/Modi) and the wrong MNRAS volume/page (527, 5929 instead of 530, 4868) for arXiv:2309.14408.

# Issues

N/A

# Checklist
I have

- [x] N/A — docs/reference-only change, no new behavior to test
- [x] N/A — no docstring behavior changed, only corrected a citation string
- [ ] N/A — not a tutorial-worthy feature
- [x] **Important**: this change does *not* break API compatibility